### PR TITLE
Update module manifest for v10

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,5 +1,5 @@
 {
-	"name": "minimal-ui",
+	"id": "minimal-ui",
 	"title": "Minimal UI",
 	"author": "JeansenVaars#2857",
 	"authors": [
@@ -17,9 +17,12 @@
 		"maximum": "10"
 	},
 	"minimumCoreVersion": "10",
-	"dependencies": [
-		{"name": "colorsettings"}
-	],
+	"relationships": {
+		"requires": [{
+			"id": "colorsettings",
+			"type": "module"
+		}]
+	},
 	"esmodules": [ "minimalui.js" ],
 	"styles": [ "minimalui.css" ],
 	"languages": [


### PR DESCRIPTION
Replace module definitions causing warnings when loading module with new v10 usage as per https://foundryvtt.com/article/manifest-migration-guide/.

This resolves issue  #108